### PR TITLE
Fixing hardcoded home path

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,7 +24,7 @@ while read slicetag repo slicename ; do
 
     # NOTE: set slice-specific source & build dirs
     export SOURCE_DIR=$PWD/$slicename
-    export BUILD_DIR=/home/$slicename
+    export BUILD_DIR=$HOME/$slicename
 
     pushd $SOURCE_DIR
         # NOTE: checkout the specific slicetag


### PR DESCRIPTION
Changing the hardcoded /home path to the $HOME environment variable, as /home breaks on systems where /home/ is not the user's home directory and/or they do not have write permissions to that directory.