### PR TITLE
Make BUILD_DIR an absolute path, from /home, rather than using $HOME

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,7 +24,7 @@ while read slicetag repo slicename ; do
 
     # NOTE: set slice-specific source & build dirs
     export SOURCE_DIR=$PWD/$slicename
-    export BUILD_DIR=$HOME/$slicename
+    export BUILD_DIR=/home/$slicename
 
     pushd $SOURCE_DIR
         # NOTE: checkout the specific slicetag


### PR DESCRIPTION
This is a change which has been in production use on mlab2.nuq0t for a long time.  This just formalizes the change by putting it in version control.