### PR TITLE
Add dockerfile for creating build environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 Docker file for creating mlab builder images.
 
 ### Building
-To build the docker image and tag it as foo/bar
+To build the docker image and tag it as m-lab/builder
 
-    docker build https://github.com/foo/build-env .
+    docker build -t m-lab/builder .
 
 ### Running the build environment
 
-    docker run foo/build-env
+    docker run m-lab/builder
 
 
 ##builder.sh

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To build the docker image and tag it as m-lab/builder
 
 ### Running the build environment
 
-    docker run m-lab/builder
+    docker run -it m-lab/builder
 
 
 ##builder.sh

--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
-builder
---------
+# MLAB slice building tools
+
+## Docker based build environment
+Docker file for creating mlab builder images.
+
+### Building
+To build the docker image and tag it as foo/bar
+
+    docker build https://github.com/foo/build-env .
+
+### Running the build environment
+
+    docker run foo/build-env
+
+
+##builder.sh
 
 Simple build script and tag list for creating slice packages.
 
@@ -16,3 +30,4 @@ To build all packages, run:
 To build a single package, specifiy the name of the slice:
 
     ./build.sh iupui_ndt
+

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,19 @@
+FROM tenforward/centos-i386
+LABEL vendor="measurement-lab" description="Docker for building 32 bit mlab slices"
+
+RUN linux32 yum -y update
+RUN linux32 yum install -y wget git svn
+RUN linux32 yum install -y binutils qt gcc make patch libgomp
+RUN linux32 yum install -y glibc-headers glibc-devel kernel-headers kernel-devel htop dkms
+RUN linux32 yum install -y rpm-builder rpm-build m4 python-devel openssl-devel
+RUN linux32 rpm -ivh http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm
+RUN linux32 yum install -y --nogpgcheck jansson-devel
+RUN linux32 yum install -y nodejs npm --enablerepo=epel
+
+ADD build.sh /root/builder
+ADD slice-tags.list /root/builder
+
+# You'll want to run this docker with -ti, otherwise it just exits.
+
+ENTRYPOINT ["linux32"]
+CMD ["/bin/bash"]

--- a/dockerfile
+++ b/dockerfile
@@ -2,10 +2,10 @@ FROM tenforward/centos-i386
 LABEL vendor="measurement-lab" description="Docker for building 32 bit mlab slices"
 
 RUN linux32 yum -y update
-RUN linux32 yum install -y wget git svn
-RUN linux32 yum install -y binutils qt gcc make patch libgomp
+RUN linux32 yum install -y wget git svn binutils qt gcc make patch libgomp
 RUN linux32 yum install -y glibc-headers glibc-devel kernel-headers kernel-devel htop dkms
 RUN linux32 yum install -y rpm-builder rpm-build m4 python-devel openssl-devel
+
 RUN linux32 rpm -ivh http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm
 RUN linux32 yum install -y --nogpgcheck jansson-devel
 RUN linux32 yum install -y nodejs npm --enablerepo=epel


### PR DESCRIPTION
Adds a docker file that produces a 32 bit docker image capable of building mlab NDT slice.

travis integration is also working in another repository, and will be introduced here shortly in a followup PR.