### PR TITLE
Travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: ruby
 services:
 - docker
 script:
-- docker build -t $TARGET_IMAGE .
-- docker inspect $TARGET_IMAGE
-- docker run $TARGET_IMAGE /root/ndt_build_and_test.sh
+- docker build -t m-lab/builder .
+- docker inspect m-lab/builder 
+
+# Build and run NDT tests as e2e sanity check
+- docker run m-lab/builder /root/ndt_build_and_test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+dist: trusty
+language: ruby
+services:
+- docker
+script:
+- docker build -t $TARGET_IMAGE .
+- docker inspect $TARGET_IMAGE
+- docker run $TARGET_IMAGE /root/ndt_build_and_test.sh

--- a/README.md
+++ b/README.md
@@ -7,11 +7,18 @@ Docker file for creating mlab builder images.
 To build the docker image and tag it as m-lab/builder
 
     docker build -t m-lab/builder .
+OR
+    docker build github.com/m-lab/builder
 
-### Running the build environment
-
+### Running the build environment interactively
     docker run -it m-lab/builder
 
+### Compiling NDT slice in 'batch' mode
+The builder includes scripts in the root directory for building and testing NDT.
+If you need the build artifacts after the build is complete, use -v to mount a
+volume on the host for either or both /root/ndt or /home/iupui_ndt.
+
+    docker run -v `pwd`/ndt:/root/ndt m-lab/builder /root/ndt_build_and_test.sh
 
 ##builder.sh
 

--- a/README.md
+++ b/README.md
@@ -37,4 +37,3 @@ To build all packages, run:
 To build a single package, specifiy the name of the slice:
 
     ./build.sh iupui_ndt
-

--- a/dockerfile
+++ b/dockerfile
@@ -10,8 +10,15 @@ RUN linux32 rpm -ivh http://download.fedoraproject.org/pub/epel/6/i386/epel-rele
 RUN linux32 yum install -y --nogpgcheck jansson-devel
 RUN linux32 yum install -y nodejs npm --enablerepo=epel
 
-ADD build.sh /root/builder
-ADD slice-tags.list /root/builder
+# These items used to be loaded through git into builder directory, so we
+# copy them into the builder directory.
+ADD build.sh /root/builder/
+ADD slice-tags.list /root/builder/
+
+# These are utility scripts that may be run directly from the docker command
+# line, e.g.
+#    docker run -v `pwd`/ndt:/root/ndt m-lab/builder /root/ndt_build_and_test.sh 
+ADD scripts /root/
 
 # You'll want to run this docker with -ti, otherwise it just exits.
 

--- a/scripts/ndt_build_and_test.sh
+++ b/scripts/ndt_build_and_test.sh
@@ -3,10 +3,11 @@ set -x
 set -e
 
 # Use a clean directory, so that we can mount it from docker run and
-# have access to the finished product.
+# have access to the finished product, when required.
 mkdir ~/ndt; cd ~/ndt; cp ~/builder/slice-tags.list .
 DISABLE_APPLET_SIGNING=1 ~/builder/build.sh iupui_ndt
 
+# Run basic unit tests that don't require web100.
 LD_LIBRARY_PATH=/home/iupui_ndt/build/lib NDT_HOSTNAME=localhost \
 ./iupui_ndt/ndt-3.7.0.1/src/web100_testoptions_unit_tests
 

--- a/scripts/ndt_build_and_test.sh
+++ b/scripts/ndt_build_and_test.sh
@@ -15,6 +15,7 @@ LD_LIBRARY_PATH=/home/iupui_ndt/build/lib NDT_HOSTNAME=localhost \
 ./iupui_ndt/ndt-3.7.0.1/src/web100_websocket_unit_tests
 
 # This test doesn't currently work on travis because it requires
-# web100 patched kernel.
+# web100 patched kernel.  When we no longer have disabled tests, we
+# should just use "make check" to run all the tests.
 # LD_LIBRARY_PATH=/home/iupui_ndt/build/lib NDT_HOSTNAME=localhost \
 # ~/builder/iupui_ndt/ndt-3.7.0.1/src/web100srv_unit_tests

--- a/scripts/ndt_build_and_test.sh
+++ b/scripts/ndt_build_and_test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -x
+set -e
+
+# Use a clean directory, so that we can mount it from docker run and
+# have access to the finished product.
+mkdir ~/ndt; cd ~/ndt; cp ~/builder/slice-tags.list .
+DISABLE_APPLET_SIGNING=1 ~/builder/build.sh iupui_ndt
+
+LD_LIBRARY_PATH=/home/iupui_ndt/build/lib NDT_HOSTNAME=localhost \
+./iupui_ndt/ndt-3.7.0.1/src/web100_testoptions_unit_tests
+
+LD_LIBRARY_PATH=/home/iupui_ndt/build/lib NDT_HOSTNAME=localhost \
+./iupui_ndt/ndt-3.7.0.1/src/web100_websocket_unit_tests
+
+# This test doesn't currently work on travis because it requires
+# web100 patched kernel.
+# LD_LIBRARY_PATH=/home/iupui_ndt/build/lib NDT_HOSTNAME=localhost \
+# ~/builder/iupui_ndt/ndt-3.7.0.1/src/web100srv_unit_tests


### PR DESCRIPTION
Adds travis integration to build the builder on travis, and test it by building NDT and running unit tests.