### PR TITLE
Extract build_one.sh to allow explicit build invocation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
 - docker
 script:
 - docker build -t m-lab/builder .
-- docker inspect m-lab/builder 
+- docker inspect m-lab/builder
 
 # Build and run NDT tests as e2e sanity check
 - docker run m-lab/builder /root/ndt_build_and_test.sh

--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@ while read slicetag repo slicename ; do
         continue
     fi
 
-    # TODO - better way to locate build_one.sh
-    ~/builder/build_one.sh $repo $slicetag $slicename
+    builddir=$( dirname "${BASH_SOURCE[0]}" )
+    $builddir/build_one.sh $repo $slicetag $slicename
 done
 

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-
-export RPMBUILD=$PWD/build/slicebase-$(uname -i)
-export TMPBUILD=$PWD/build/tmp
 SLICE=${1:?Error: please provide name of slice to build, or 'all'}
 
 set -x
@@ -10,28 +7,12 @@ set -e
 
 # NOTE: for each non-comment line
 grep -v "^#" slice-tags.list | \
-while read slicetag repo slicename ; do 
-
+while read slicetag repo slicename ; do
     if test x"$SLICE" != x"all" && test x"$SLICE" != x"$slicename" ; then
         continue
     fi
 
-    # NOTE: remove old slice dir, if present 
-    test -d $slicename && rm -rf $slicename
-
-    # NOTE: checkout repo
-    git clone --recursive $repo $slicename
-
-    # NOTE: set slice-specific source & build dirs
-    export SOURCE_DIR=$PWD/$slicename
-    export BUILD_DIR=/home/$slicename
-
-    pushd $SOURCE_DIR
-        # NOTE: checkout the specific slicetag
-        git checkout --quiet $slicetag
-
-        # NOTE: perform build & pass 'export'd vars through environment
-        ./package/slicebuild.sh $slicename
-    popd
+    # TODO - better way to locate build_one.sh
+    ~/builder/build_one.sh $repo $slicetag $slicename
 done
 

--- a/build_one.sh
+++ b/build_one.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+export RPMBUILD=$PWD/build/slicebase-$(uname -i)
+export TMPBUILD=$PWD/build/tmp
+REPO=${1:?Usage: ./build_one.sh repo tag slice-name}
+TAG=${2:?Usage: ./build_one.sh repo tag slice-name}
+NAME=${3:?Usage: ./build_one.sh repo tag slice-name}
+
+set -x
+set -e
+
+# NOTE: remove old slice dir, if present 
+test -d $NAME && rm -rf $NAME
+
+# NOTE: checkout repo
+git clone --recursive $REPO $NAME
+
+# NOTE: set slice-specific source & build dirs
+export SOURCE_DIR=$PWD/$NAME
+export BUILD_DIR=/home/$NAME
+
+pushd $SOURCE_DIR
+    # NOTE: checkout the specific slicetag
+    git checkout --quiet $TAG
+
+    # NOTE: perform build & pass 'export'd vars through environment
+    ./package/slicebuild.sh $NAME
+popd
+

--- a/dockerfile
+++ b/dockerfile
@@ -9,15 +9,17 @@ RUN linux32 yum install -y rpm-builder rpm-build m4 python-devel openssl-devel
 RUN linux32 rpm -ivh http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm
 RUN linux32 yum install -y --nogpgcheck jansson-devel
 RUN linux32 yum install -y nodejs npm --enablerepo=epel
+RUN linux32 yum install -y sudo man
 
 # These items used to be loaded through git into builder directory, so we
 # copy them into the builder directory.
 ADD build.sh /root/builder/
+ADD build_one.sh /root/builder/
 ADD slice-tags.list /root/builder/
 
 # These are utility scripts that may be run directly from the docker command
 # line, e.g.
-#    docker run -v `pwd`/ndt:/root/ndt m-lab/builder /root/ndt_build_and_test.sh 
+#    docker run -v `pwd`/ndt:/root/ndt m-lab/builder /root/ndt_build_and_test.sh
 ADD scripts /root/
 
 # You'll want to run this docker with -ti, otherwise it just exits.


### PR DESCRIPTION
Travis integration for npad-support will directly build the slice, rather than using slice-tags.list.  This PR separates out the required shell code to allow calling directly.

Also adds man and sudo to builder image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/builder/9)
<!-- Reviewable:end -->
