### PR TITLE
Update builder to actually build the right version of NDT.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,6 @@ script:
 - docker inspect m-lab/builder
 
 # Build and run NDT tests as e2e sanity check
-- docker run m-lab/builder /root/ndt_build_and_test.sh
+# Temporarily, this builds the dev branch, as a step to getting
+# everything working correctly.  Move to master asap.
+- docker run m-lab/builder /root/ndt_build_and_test.sh dev

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # MLAB slice building tools
 
+| branch | travis-ci | coveralls |
+|--------|-----------|-----------|
+| master | [![Travis Build Status](https://travis-ci.org/m-lab/builder.svg?branch=master)](https://travis-ci.org/m-lab/builder) | [![Coverage Status](https://coveralls.io/repos/m-lab/builder/badge.svg?branch=master)](https://coveralls.io/github/m-lab/builder?branch=master) |
+| dev | [![Travis Build Status](https://travis-ci.org/m-lab/builder.svg?branch=dev)](https://travis-ci.org/m-lab/builder) | [![Coverage Status](https://coveralls.io/repos/m-lab/builder/badge.svg?branch=dev)](https://coveralls.io/github/m-lab/builder?branch=dev) |
+
+
 ## Docker based build environment
 Docker file for creating mlab builder images.
 
@@ -24,7 +30,7 @@ volume on the host for either or both /root/ndt or /home/iupui_ndt.
 
 Simple build script and tag list for creating slice packages.
 
-The slice-tags.list contains a list of triples: 
+The slice-tags.list contains a list of triples:
 
     tag_name git_repository_url slice_name
 

--- a/scripts/ndt_build_and_test.sh
+++ b/scripts/ndt_build_and_test.sh
@@ -9,13 +9,13 @@ DISABLE_APPLET_SIGNING=1 ~/builder/build.sh iupui_ndt
 
 # Run basic unit tests that don't require web100.
 LD_LIBRARY_PATH=/home/iupui_ndt/build/lib NDT_HOSTNAME=localhost \
-./iupui_ndt/ndt-3.7.0.1/src/web100_testoptions_unit_tests
+./iupui_ndt/ndt/src/web100_testoptions_unit_tests
 
 LD_LIBRARY_PATH=/home/iupui_ndt/build/lib NDT_HOSTNAME=localhost \
-./iupui_ndt/ndt-3.7.0.1/src/web100_websocket_unit_tests
+./iupui_ndt/ndt/src/web100_websocket_unit_tests
 
 # This test doesn't currently work on travis because it requires
 # web100 patched kernel.  When we no longer have disabled tests, we
 # should just use "make check" to run all the tests.
 # LD_LIBRARY_PATH=/home/iupui_ndt/build/lib NDT_HOSTNAME=localhost \
-# ~/builder/iupui_ndt/ndt-3.7.0.1/src/web100srv_unit_tests
+# ~/builder/iupui_ndt/ndt/src/web100srv_unit_tests

--- a/scripts/ndt_build_and_test.sh
+++ b/scripts/ndt_build_and_test.sh
@@ -2,10 +2,16 @@
 set -x
 set -e
 
+BRANCH_OR_TAG=${1:-master}
+
 # Use a clean directory, so that we can mount it from docker run and
 # have access to the finished product, when required.
-mkdir ~/ndt; cd ~/ndt; cp ~/builder/slice-tags.list .
-DISABLE_APPLET_SIGNING=1 ~/builder/build.sh iupui_ndt
+mkdir ~/ndt; cd ~/ndt
+
+# This builds the branch or tag specified as $1.  If no argument, then
+# it builds the master branch.
+DISABLE_APPLET_SIGNING=1 ~/builder/build_one.sh \
+  https://github.com/m-lab/ndt-support.git ${BRANCH_OR_TAG} iupui_ndt
 
 # Run basic unit tests that don't require web100.
 LD_LIBRARY_PATH=/home/iupui_ndt/build/lib NDT_HOSTNAME=localhost \

--- a/slice-tags.list
+++ b/slice-tags.list
@@ -1,11 +1,10 @@
 # <tag/branch>       <repo-url>  <slicename>
 # NOTE: This file is ignored when building ndt using new build container.
-4.0.0.1-201611171214.mlab     https://github.com/m-lab/ndt-support.git          iupui_ndt
-1.5.7.pre1-201702141214.mlab  https://github.com/m-lab/npad-support.git         iupui_npad
-1.0-18.mlab                   https://github.com/m-lab/mobiperf-support.git     michigan_1
-20.02.2014-21.mlab            https://github.com/m-lab/glasnost-support.git     mpisws_broadband
-0.6.0.5-201701171515.mlab     https://github.com/m-lab/neubot-support.git       mlab_neubot
-1.5-201606091715.mlab         https://github.com/m-lab/utility-support.git      mlab_utility
-#1.0-58.mlab                  https://github.com/m-lab/utility-support.git      mlab_utility
-1.0.0-189.mlab                https://github.com/m-lab/ooni-support.git         mlab_ooni
+4.0.0.1-201611171214.mlab    https://github.com/m-lab/ndt-support.git      iupui_ndt
+1.5.7.pre1-201702141214.mlab https://github.com/m-lab/npad-support.git     iupui_npad
+1.0-18.mlab                  https://github.com/m-lab/mobiperf-support.git michigan_1
+20.02.2014-21.mlab           https://github.com/m-lab/glasnost-support.git mpisws_broadband
+0.6.0.5-201701171515.mlab    https://github.com/m-lab/neubot-support.git   mlab_neubot
+1.5-201606091715.mlab        https://github.com/m-lab/utility-support.git  mlab_utility
+1.0.0-189.mlab               https://github.com/m-lab/ooni-support.git     mlab_ooni
 

--- a/slice-tags.list
+++ b/slice-tags.list
@@ -1,8 +1,11 @@
 # <tag/branch>       <repo-url>  <slicename>
-3.7.0-112.mlab      https://github.com/m-lab/ndt-support.git          iupui_ndt
-1.5.7.pre1-56.mlab  https://github.com/m-lab/npad-support.git         iupui_npad
-1.0-18.mlab         https://github.com/m-lab/mobiperf-support.git     michigan_1
-20.02.2014-21.mlab  https://github.com/m-lab/glasnost-support.git     mpisws_broadband
-0.4.16.9-2.mlab     https://github.com/m-lab/neubot-support.git       mlab_neubot
-1.0-58.mlab         https://github.com/m-lab/utility-support.git      mlab_utility
-1.0.0-189.mlab      https://github.com/m-lab/ooni-support.git         mlab_ooni
+# NOTE: This file is ignored when building ndt using new build container.
+4.0.0.1-201611171214.mlab     https://github.com/m-lab/ndt-support.git          iupui_ndt
+1.5.7.pre1-201702141214.mlab  https://github.com/m-lab/npad-support.git         iupui_npad
+1.0-18.mlab                   https://github.com/m-lab/mobiperf-support.git     michigan_1
+20.02.2014-21.mlab            https://github.com/m-lab/glasnost-support.git     mpisws_broadband
+0.6.0.5-201701171515.mlab     https://github.com/m-lab/neubot-support.git       mlab_neubot
+1.5-201606091715.mlab         https://github.com/m-lab/utility-support.git      mlab_utility
+#1.0-58.mlab                  https://github.com/m-lab/utility-support.git      mlab_utility
+1.0.0-189.mlab                https://github.com/m-lab/ooni-support.git         mlab_ooni
+


### PR DESCRIPTION
Update slice tags to most recent values from mlab_builder.
Modify ndt_build_and_test to use build_one.sh and ignore slice-tags.list.
Modify build script to build m-lab/ndt instead of -3.7 tar file.
Use the dev branch of ndt-support to test the build environment.
Add badges to README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/builder/11)
<!-- Reviewable:end -->
