### PR TITLE
Clone builder repo into Docker image rather than cherry-picking files at build time

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -11,11 +11,8 @@ RUN linux32 yum install -y --nogpgcheck jansson-devel
 RUN linux32 yum install -y nodejs npm --enablerepo=epel
 RUN linux32 yum install -y sudo man
 
-# These items used to be loaded through git into builder directory, so we
-# copy them into the builder directory.
-ADD build.sh /root/builder/
-ADD build_one.sh /root/builder/
-ADD slice-tags.list /root/builder/
+# Clone the builder repository into /root/builder
+RUN git clone https://github.com/m-lab/builder.git /root/builder
 
 # These are utility scripts that may be run directly from the docker command
 # line, e.g.


### PR DESCRIPTION
Rather than cherry-picking a few files from this repository into the Docker image, just clone this repository inside the image. This should make updating easier, since the image doesn't have to be rebuilt every time this repository changes, but the user can simply do a `git-pull` inside a running image. This may also facilitate having a semi-permanent build VM running the Docker image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/builder/13)
<!-- Reviewable:end -->
