### PR TITLE
Works around the 'Rpmdb checksum is invalid' issue on older CentOS images.

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -3,7 +3,7 @@ LABEL vendor="measurement-lab" description="Docker for building 32 bit mlab slic
 
 RUN touch /var/lib/rpm/* && linux32 yum install -y yum-plugin-ovl
 RUN linux32 yum -y update
-RUN linux32 yum install -y wget git svn binutils qt gcc make patch libgomp
+RUN linux32 yum install -y wget git svn binutils qt gcc make patch libgomp golang
 RUN linux32 yum install -y glibc-headers glibc-devel kernel-headers kernel-devel htop dkms
 RUN linux32 yum install -y rpm-builder rpm-build m4 python-devel openssl-devel
 

--- a/dockerfile
+++ b/dockerfile
@@ -1,6 +1,7 @@
 FROM tenforward/centos-i386
 LABEL vendor="measurement-lab" description="Docker for building 32 bit mlab slices"
 
+RUN touch /var/lib/rpm/* && linux32 yum install -y yum-plugin-ovl
 RUN linux32 yum -y update
 RUN linux32 yum install -y wget git svn binutils qt gcc make patch libgomp
 RUN linux32 yum install -y glibc-headers glibc-devel kernel-headers kernel-devel htop dkms


### PR DESCRIPTION
There is some issue with overlayfs and older CentOS images that results in `yum` operations failing in a Dockerfile with some error like:

`Rpmdb checksum is invalid: dCDPT(pkg checksums): <some package name>`

This PR implements a couple workarounds gleaned from [various Github issues addressing this problem](https://www.google.com/search?q=debian+docker+Rpmdb+checksum+is+invalid).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/builder/14)
<!-- Reviewable:end -->
