### PR TITLE
Moves installation of golang later, when the epel repo has been enabled.

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -3,13 +3,13 @@ LABEL vendor="measurement-lab" description="Docker for building 32 bit mlab slic
 
 RUN touch /var/lib/rpm/* && linux32 yum install -y yum-plugin-ovl
 RUN linux32 yum -y update
-RUN linux32 yum install -y wget git svn binutils qt gcc make patch libgomp golang
+RUN linux32 yum install -y wget git svn binutils qt gcc make patch libgomp
 RUN linux32 yum install -y glibc-headers glibc-devel kernel-headers kernel-devel htop dkms
 RUN linux32 yum install -y rpm-builder rpm-build m4 python-devel openssl-devel
 
 RUN linux32 rpm -ivh http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm
 RUN linux32 yum install -y --nogpgcheck jansson-devel
-RUN linux32 yum install -y nodejs npm --enablerepo=epel
+RUN linux32 yum install -y nodejs npm golang --enablerepo=epel
 RUN linux32 yum install -y sudo man
 
 # Clone the builder repository into /root/builder


### PR DESCRIPTION
golang installation was not happening because apparently golang is included in the epel repository, which was not being enabled until a later step in the Dockerfile. This PR just moves the installation of golang to a step where the epel repository has already been installed and is being explicitly enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/builder/16)
<!-- Reviewable:end -->
